### PR TITLE
Fix/dont require city state

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,11 @@ repos:
     hooks:
       - id: autopep8
         args: ['--in-place', '--aggressive', '--aggressive', '--recursive', '--max-line-length=100', '--ignore=E501,E402,W503,E731']
-  - repo: https://github.com/humitos/mirrors-autoflake.git
-    rev: v1.1
+  - repo: https://github.com/myint/autoflake.git
+    rev: v1.4
     hooks:
       - id: autoflake
-        args: ['--in-place', '--recursive', '--remove-all-unused-imports', '--remove-unused-variable', '--ignore-init-module-imports']
+        args: ['--in-place', '--recursive', '--remove-all-unused-imports', '--remove-unused-variable' , '--ignore-init-module-imports']
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:

--- a/hasty/generate/models.py
+++ b/hasty/generate/models.py
@@ -140,8 +140,8 @@ class Site(models.Model):
 
     id = models.UUIDField(primary_key=True, default=uuid4)
     name = models.CharField(max_length=50)
-    city = models.CharField(max_length=50)
-    state = models.CharField(max_length=2, choices=STATES)
+    city = models.CharField(max_length=50, default=None, null=True)
+    state = models.CharField(max_length=2, choices=STATES, default=None, null=True)
     zip = models.IntegerField()
 
 

--- a/hasty/lib/deserialization.py
+++ b/hasty/lib/deserialization.py
@@ -49,7 +49,7 @@ def find_tagset(entities, tags):
 
 def save_site(site):
     site = site[0]
-    site_id = str(site.get('id')[2:])  # remove "r:" from UUID
+    site_id = str(site.get('id'))  # [2:])  # remove "r:" from UUID
     site_name = site.get('dis')
     geo_city = site.get('geoCity')
     geo_state = site.get('geoState')


### PR DESCRIPTION
NREL's Haystack JSON versions of the DOE prototype/reference buildings were causing an error because they do not include a `geoCity` or `geoState`. These commits allow the "reference implementations" to be opened...hastily.